### PR TITLE
point out new development URLs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,5 @@
+Discourse has taken up development of this plugin in this repo:  
+
+https://github.com/discourse/discourse-zendesk-plugin  
+
+Read more at https://meta.discourse.org/t/discourse-zendesk-plugin/68005  


### PR DESCRIPTION
Discourse has taken up development of this plugin in this repo:  

https://github.com/discourse/discourse-zendesk-plugin  

Read more at https://meta.discourse.org/t/discourse-zendesk-plugin/68005  